### PR TITLE
Add Kerberos config and schema defaults for metadata service

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,23 @@ Kerberos authentication relies on Oracle's thick client. Export the following en
 export ORACLE_DSN="//db-host.example.com:1521/ORCLPDB1"
 export ORACLE_CONFIG_DIR="/opt/oracle/kerberos"    # directory containing sqlnet.ora & krb5.conf
 export ORACLE_LIB_DIR="/opt/oracle/instantclient_19_8"  # location of Instant Client libraries
+export ORACLE_KRB5_CONFIG="/etc/krb5.conf"             # optional explicit Kerberos configuration file
+export ORACLE_KRB5_CREDENTIALS_CACHE="/tmp/krb5cc_$(id -u)"  # optional credential cache location
 export ORACLE_USE_THICK=true
 export ORACLE_USE_POOL=true
 export ORACLE_POOL_MIN=1
 export ORACLE_POOL_MAX=5
 export ORACLE_POOL_INCREMENT=1
 export METADATA_RECENT_MONTHS=6
+export METADATA_SCHEMA="HR"                               # optional default schema for metadata APIs
+export METADATA_TABLES="EMPLOYEES,DEPARTMENTS"            # optional comma-separated table list
 ```
 
 The `ORACLE_CONFIG_DIR` directory should contain the Kerberos configuration (`sqlnet.ora`, `krb5.conf`). Ensure that Kerberos tickets are available (e.g., via `kinit`) for the process identity. The Oracle server must be configured to trust Kerberos-authenticated clients.
+
+When `ORACLE_KRB5_CONFIG` or `ORACLE_KRB5_CREDENTIALS_CACHE` are provided, the service sets the corresponding `KRB5_CONFIG` and `KRB5CCNAME` environment variables before initializing the Oracle client. This makes it easy to point the connector at alternate Kerberos configuration files or ticket caches without modifying the host environment.
+
+If you regularly work with a specific schema, `METADATA_SCHEMA` and `METADATA_TABLES` allow you to define the default schema and a comma-separated list of tables to inspect. When these variables are set, the metadata service automatically scopes table discovery and manifest generation to the configured tables whenever you request that schema.
 
 ## Installation
 

--- a/app/config.py
+++ b/app/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Optional
+from typing import Optional, Tuple
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -21,6 +21,14 @@ def _env_int(name: str, default: int) -> int:
     return int(value)
 
 
+def _env_list(name: str) -> Tuple[str, ...]:
+    value = os.getenv(name)
+    if value is None:
+        return ()
+    items = [item.strip() for item in value.split(",")]
+    return tuple(item for item in items if item)
+
+
 @dataclass
 class Settings:
     """Runtime settings for the metadata service."""
@@ -35,6 +43,10 @@ class Settings:
     oracle_pool_increment: int = 1
     oracle_fetch_arraysize: int = 100
     metadata_recent_months: int = 6
+    kerberos_config_file: Optional[str] = None
+    kerberos_credentials_cache: Optional[str] = None
+    metadata_schema: Optional[str] = None
+    metadata_tables: Tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if not self.oracle_dsn:
@@ -45,6 +57,12 @@ class Settings:
             raise ValueError("oracle_pool_increment must be positive")
         if self.metadata_recent_months < 0:
             raise ValueError("metadata_recent_months must be non-negative")
+        if self.metadata_schema:
+            self.metadata_schema = self.metadata_schema.upper()
+        if self.metadata_tables is None:
+            self.metadata_tables = ()
+        if self.metadata_tables:
+            self.metadata_tables = tuple(name.upper() for name in self.metadata_tables if name)
 
     @classmethod
     def from_env(cls) -> "Settings":
@@ -62,6 +80,12 @@ class Settings:
             oracle_pool_increment=_env_int("ORACLE_POOL_INCREMENT", 1),
             oracle_fetch_arraysize=_env_int("ORACLE_FETCH_ARRAYSIZE", 100),
             metadata_recent_months=_env_int("METADATA_RECENT_MONTHS", 6),
+            kerberos_config_file=os.getenv("ORACLE_KRB5_CONFIG")
+            or os.getenv("KRB5_CONFIG"),
+            kerberos_credentials_cache=os.getenv("ORACLE_KRB5_CREDENTIALS_CACHE")
+            or os.getenv("KRB5CCNAME"),
+            metadata_schema=os.getenv("METADATA_SCHEMA"),
+            metadata_tables=_env_list("METADATA_TABLES"),
         )
 
 

--- a/app/db.py
+++ b/app/db.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from contextlib import contextmanager
 from typing import Any, Dict, List, Optional
@@ -28,6 +29,15 @@ class OracleClient:
         self._settings = settings
         self._pool: Optional["oracledb.SessionPool"] = None
         self._pool_lock = threading.Lock()
+
+        if settings.kerberos_config_file:
+            os.environ["KRB5_CONFIG"] = settings.kerberos_config_file
+            logger.debug("Set KRB5_CONFIG to %s", settings.kerberos_config_file)
+        if settings.kerberos_credentials_cache:
+            os.environ["KRB5CCNAME"] = settings.kerberos_credentials_cache
+            logger.debug(
+                "Set KRB5CCNAME to %s", settings.kerberos_credentials_cache
+            )
 
         if settings.oracle_use_thick:
             logger.debug(

--- a/app/services/metadata.py
+++ b/app/services/metadata.py
@@ -66,8 +66,18 @@ class OracleMetadataService:
         threshold = self._months_ago(months)
         available_tables = self._list_table_names(normalized_schema)
 
-        if table_names:
-            requested = {name.upper() for name in table_names}
+        configured_tables = self._configured_tables_for_schema(normalized_schema)
+        effective_table_names = table_names
+        if effective_table_names is None and configured_tables:
+            logger.debug(
+                "Restricting table inspection for %s to configured tables: %s",
+                normalized_schema,
+                ", ".join(configured_tables),
+            )
+            effective_table_names = configured_tables
+
+        if effective_table_names:
+            requested = {name.upper() for name in effective_table_names}
             target_tables = [name for name in available_tables if name in requested]
             missing = requested.difference(available_tables)
             if missing:
@@ -103,6 +113,7 @@ class OracleMetadataService:
         normalized_schema = schema.upper()
         months = months or self._settings.metadata_recent_months
         table_profiles: Dict[str, TableProfile] = {}
+        configured_tables = self._configured_tables_for_schema(normalized_schema)
 
         if tables:
             requested_tables = [name.upper() for name in tables]
@@ -112,6 +123,13 @@ class OracleMetadataService:
                 raise ValueError(
                     f"Tables not found in schema {normalized_schema}: {', '.join(sorted(missing))}"
                 )
+        elif configured_tables:
+            requested_tables = list(configured_tables)
+            logger.debug(
+                "Using configured tables for schema %s when generating metadata: %s",
+                normalized_schema,
+                ", ".join(requested_tables),
+            )
         else:
             requested_tables = None
 
@@ -397,6 +415,14 @@ class OracleMetadataService:
         """
         rows = self._client.fetchall(sql, {"schema": schema, "table": table})
         return [row["column_name"] for row in rows]
+
+    def _configured_tables_for_schema(self, schema: str) -> Optional[List[str]]:
+        configured_schema = self._settings.metadata_schema
+        if configured_schema and schema == configured_schema:
+            tables = list(self._settings.metadata_tables)
+            if tables:
+                return tables
+        return None
 
     def _coerce_int(self, value: Optional[object]) -> Optional[int]:
         if value is None:

--- a/tests/test_metadata_service.py
+++ b/tests/test_metadata_service.py
@@ -165,3 +165,32 @@ def test_generate_mdl_applies_filter(service):
     manifest = service.generate_mdl(catalog="Demo", schema="TEST")
     assert len(manifest["models"]) == 1
     assert manifest["models"][0]["name"] == "ACTIVE_TABLE"
+
+
+def test_configured_tables_scope_results(service):
+    settings = Settings(
+        oracle_dsn="//testdb",
+        metadata_schema="TEST",
+        metadata_tables=("ACTIVE_TABLE", "EMPTY_TABLE"),
+    )
+    client = FakeOracleClient(now=datetime.utcnow())
+    configured_service = OracleMetadataService(client, settings)
+    tables = configured_service.get_filtered_tables("TEST")
+    assert [table.table_name for table in tables] == ["ACTIVE_TABLE"]
+
+
+def test_generate_mdl_uses_configured_tables_when_unfiltered():
+    settings = Settings(
+        oracle_dsn="//testdb",
+        metadata_schema="TEST",
+        metadata_tables=("ACTIVE_TABLE", "EMPTY_TABLE"),
+    )
+    client = FakeOracleClient(now=datetime.utcnow())
+    configured_service = OracleMetadataService(client, settings)
+    manifest = configured_service.generate_mdl(
+        catalog="Demo",
+        schema="TEST",
+        apply_usage_filter=False,
+    )
+    names = [model["name"] for model in manifest["models"]]
+    assert names == ["ACTIVE_TABLE", "EMPTY_TABLE"]


### PR DESCRIPTION
## Summary
- add settings for Kerberos configuration files and credential cache and set the associated environment variables before initializing the Oracle client
- allow configuring a default schema and table list so metadata queries automatically scope to those tables when requested
- document the new settings and extend metadata service tests for configured tables

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d36a63172083278de60a2c88cb5345